### PR TITLE
Fix postgres user in TestGen healthcheck

### DIFF
--- a/dk-installer.py
+++ b/dk-installer.py
@@ -1362,7 +1362,7 @@ class TestGenCreateDockerComposeFileStep(Step):
                 volumes:
                   - postgres_data:/var/lib/postgresql/data
                 healthcheck:
-                  test: ["CMD-SHELL", "pg_isready -U postgres"]
+                  test: ["CMD-SHELL", "pg_isready -U {username}"]
                   interval: 8s
                   timeout: 5s
                   retries: 3


### PR DESCRIPTION
The health check in the TestGen postges container keeps failing with `FATAL:  role “postgres” does not exist`. This is because the wrong user was being used for the check.