### PR TITLE
Add pull-timeout arg & change default minikube driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,6 @@ And it allows you to <b>make fast, safe development changes</b>.
 |-------------------------|-------------------------|-------------------------------|
 | [Minikube](https://minikube.sigs.k8s.io/docs/start/)         | 1.33, 1.34, 1.35                | `minikube version`                |
 | [Helm](https://helm.sh/docs/intro/install/)            | 3.13, 3.14        | `helm version`         |
-| Minikube Driver <br/>- macOS on Intel chip: [HyperKit](https://minikube.sigs.k8s.io/docs/drivers/hyperkit/) <br/>- Other operating systems: [Docker](https://minikube.sigs.k8s.io/docs/drivers/docker/) | <br/>0.20210107 <br/> 25.0, 26.1, 27.5             | <br/>`hyperkit -v` <br/>`docker -v`         |
 
 ### Download the installer
 

--- a/dk-installer.py
+++ b/dk-installer.py
@@ -104,13 +104,6 @@ def collect_images_digest(action, images, env=None):
     )
 
 
-def get_recommended_minikube_driver():
-    if platform.system() == "Darwin" and platform.processor() == "i386":
-        return "hyperkit"
-    else:
-        return "docker"
-
-
 def collect_user_input(fields: list[str]) -> dict[str, str]:
     res = {}
     CONSOLE.space()
@@ -1263,7 +1256,7 @@ class ObsInstallAction(AnalyticsMultiStepAction):
             "--driver",
             type=str,
             action="store",
-            default=get_recommended_minikube_driver(),
+            default="docker",
             help="Minikube driver to be used. Defaults to '%(default)s'",
         )
         parser.add_argument(


### PR DESCRIPTION
- Add a `--pull-timeout` argument for TestGen install. Change default pull timeout to 5 mins.
- Change default Minikube driver for Observability install to Docker for all operating systems.