### PR TITLE
feat: Adding an specific requisite check for pulling the TG image

### DIFF
--- a/dk-installer.py
+++ b/dk-installer.py
@@ -993,7 +993,7 @@ REQ_TESTGEN_IMAGE = Requirement(
     "TESTGEN_IMAGE",
     ("docker", "manifest", "inspect", "{image}"),
     (
-        "The Docker engine could not access the TestGen's image.",
+        "The Docker engine could not access TestGen's image.",
         "Make sure your networking policy allows Docker to pull the {image} image.",
     ),
 )

--- a/dk-installer.py
+++ b/dk-installer.py
@@ -986,8 +986,16 @@ REQ_DOCKER = Requirement(
 )
 REQ_DOCKER_DAEMON = Requirement(
     "DOCKER_ENGINE",
-    ("docker", "info"),
+    ("docker", "system", "events", "--since=0m", "--until=0m"),
     ("The Docker engine is not running.", "Start the Docker engine and try again."),
+)
+REQ_TESTGEN_IMAGE = Requirement(
+    "TESTGEN_IMAGE",
+    ("docker", "manifest", "inspect", "{image}"),
+    (
+        "The Docker engine could not access the TestGen's image.",
+        "Make sure your networking policy allows Docker to pull the {image} image.",
+    ),
 )
 
 
@@ -2046,7 +2054,7 @@ class TestgenInstallAction(TestgenActionMixin, AnalyticsMultiStepAction):
     intro_text = ["This process may take 5~10 minutes depending on your system resources and network speed."]
 
     args_cmd = "install"
-    requirements = [REQ_DOCKER, REQ_DOCKER_DAEMON]
+    requirements = [REQ_DOCKER, REQ_DOCKER_DAEMON, REQ_TESTGEN_IMAGE]
 
     def __init__(self):
         super().__init__()
@@ -2115,6 +2123,7 @@ class TestgenUpgradeAction(TestgenActionMixin, AnalyticsMultiStepAction):
         return [
             REQ_DOCKER,
             REQ_DOCKER_DAEMON,
+            REQ_TESTGEN_IMAGE,
             Requirement(
                 "TG_COMPOSE_FILE",
                 (

--- a/tests/test_tg_upgrade.py
+++ b/tests/test_tg_upgrade.py
@@ -60,7 +60,7 @@ def get_compose_content(*extra_vars):
 
 @pytest.mark.integration
 def test_tg_upgrade_compose_missing(tg_upgrade_action, args_mock, start_cmd_mock, console_msg_mock):
-    start_cmd_mock.__exit__.side_effect = [None, None, CommandFailed]
+    start_cmd_mock.__exit__.side_effect = [None, None, None, CommandFailed]
 
     with pytest.raises(AbortAction, match=""):
         tg_upgrade_action._check_requirements(args_mock)


### PR DESCRIPTION
Added an specific requisite check for pulling the TestGen image.

This is how it looks when the installer can't check the image manifests:

<img width="912" alt="Screenshot 2025-07-01 at 11 25 45 AM" src="https://github.com/user-attachments/assets/ffed18bc-ad84-45c0-bf24-517c0d1a4d64" />

When docker is not running, both requisites fails:

<img width="913" alt="Screenshot 2025-07-01 at 11 27 05 AM" src="https://github.com/user-attachments/assets/0ec4b472-3184-4542-ade9-9e55cf01d7d1" />

