### PR TITLE
fix(installer): cleanup orphan testgen+postgres and log-file encoding on Windows

### DIFF
--- a/dk-installer.py
+++ b/dk-installer.py
@@ -684,6 +684,10 @@ class Action:
                         "class": "logging.FileHandler",
                         "filename": str(file_path),
                         "formatter": "file",
+                        # Default is locale.getpreferredencoding(), which is
+                        # cp1252 on US Windows — chokes on non-ASCII chars like
+                        # ✓ that the installer prints in prereq status lines.
+                        "encoding": "utf-8",
                     },
                     "console": {
                         "level": "DEBUG",

--- a/dk-installer.py
+++ b/dk-installer.py
@@ -2508,6 +2508,71 @@ def stop_app_tree(proc: subprocess.Popen, timeout: int = 10) -> None:
             proc.wait(timeout=5)
 
 
+def stop_standalone_orphans() -> None:
+    """Best-effort kill of orphan ``testgen`` + embedded ``postgres`` processes
+    left over from a previous dirty exit.
+
+    Called before steps that need a clean slate (``tg delete`` and the
+    standalone-setup step of ``tg install``). Silent on the happy path —
+    only logs when something is actually killed.
+
+    Postgres is targeted by PID via ``<pgdata>/postmaster.pid`` so a user's
+    other Postgres installs aren't touched. ``testgen.exe`` is targeted by
+    image name on Windows — the installer itself is ``dk-installer.exe``,
+    so there's no risk of self-kill. Killing ``testgen.exe`` before
+    ``uv tool uninstall`` also matters on Windows: a running .exe holds an
+    exclusive file lock, so ``uv`` would otherwise fail to delete the binary.
+    """
+    # Outer guard so a transient filesystem/permission glitch in this best-effort
+    # cleanup can never crash the install or delete flow.
+    try:
+        tg_home_env = os.environ.get("TG_TESTGEN_HOME")
+        tg_home = pathlib.Path(tg_home_env) if tg_home_env else pathlib.Path.home() / ".testgen"
+        pid_file = tg_home / "pgdata" / "postmaster.pid"
+        is_windows = platform.system() == "Windows"
+
+        if pid_file.exists():
+            with contextlib.suppress(Exception):
+                postgres_pid = int(pid_file.read_text().splitlines()[0].strip())
+                LOG.info("Stopping orphan postgres (PID %d) from previous session", postgres_pid)
+                if is_windows:
+                    subprocess.run(
+                        ["taskkill", "/F", "/T", "/PID", str(postgres_pid)],
+                        stdout=subprocess.DEVNULL,
+                        stderr=subprocess.DEVNULL,
+                        creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0),
+                        check=False,
+                    )
+                else:
+                    with contextlib.suppress(ProcessLookupError):
+                        os.kill(postgres_pid, signal.SIGKILL)
+
+        if is_windows:
+            # Image-name match — covers any leftover `testgen run-app` parents.
+            # `/T` propagates to their children (UI/scheduler/server subprocesses).
+            with contextlib.suppress(Exception):
+                subprocess.run(
+                    ["taskkill", "/F", "/T", "/IM", "testgen.exe"],
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                    creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0),
+                    check=False,
+                )
+        else:
+            # `pkill -f` matches against the full command line. The installer's own
+            # argv is `python dk-installer.py …` — doesn't contain `run-app`, so
+            # no self-kill risk.
+            with contextlib.suppress(Exception):
+                subprocess.run(
+                    ["pkill", "-9", "-f", r"testgen.*run-app"],
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                    check=False,
+                )
+    except Exception:
+        LOG.exception("Unexpected error during orphan cleanup; continuing")
+
+
 def start_testgen_app(action, args) -> None:
     """Start ``testgen run-app`` and block until the user interrupts.
 
@@ -2624,6 +2689,10 @@ class TestgenStandaloneSetupStep(Step):
     def pre_execute(self, action, args):
         self.username = DEFAULT_USER_DATA["username"]
         self.password = generate_password()
+        # Reach here only after `_resolve_install_mode` confirmed no existing
+        # install marker — so any running testgen/postgres processes are
+        # orphans from a previous dirty exit, safe to force-kill.
+        stop_standalone_orphans()
 
     def execute(self, action, args):
         # standalone-setup persists these env vars to ~/.testgen/config.env so
@@ -3101,6 +3170,13 @@ class TestgenDeleteAction(Action, ComposeActionMixin):
 
     def _delete_pip(self, args):
         CONSOLE.title("Delete TestGen instance")
+
+        # Stop any running testgen + embedded postgres before touching the
+        # installation. On Windows, a live testgen.exe locks its own binary
+        # so `uv tool uninstall` would fail to remove it; on either platform,
+        # a live postgres holds file handles into ~/.testgen that block
+        # `shutil.rmtree` from completing cleanly.
+        stop_standalone_orphans()
 
         uv_path = resolve_uv_path(self.data_folder)
         if uv_path:


### PR DESCRIPTION
## Summary
Two Windows-installer robustness fixes surfaced while testing TG-1083.

1. **Orphan cleanup before install/delete.** When a previous standalone session exited dirty (force-killed via Task Manager, browser tab close, etc.), the embedded postgres survives — it was spawned with \`CREATE_NEW_PROCESS_GROUP | CREATE_NO_WINDOW\`. Next \`tg install\` then fails at \`standalone-setup\` because the orphan still owns \`~/.testgen/pgdata\`; next \`tg delete\` half-finishes because Windows file-locks the running \`testgen.exe\` binary, blocking \`uv tool uninstall\`. New \`stop_standalone_orphans()\` helper kills the postgres PID read from \`postmaster.pid\` (precise — other Postgres installs untouched) and force-kills \`testgen.exe\` by image name (safe — installer is \`dk-installer.exe\`). Wired into \`_delete_pip\` and \`TestgenStandaloneSetupStep.pre_execute\`. The pre-execute hook runs only after \`_resolve_install_mode\` confirms no install marker, so the existing "you already have an install" guard is preserved.
2. **UTF-8 log file.** \`logging.FileHandler\` was being constructed without an \`encoding=\` argument, so on Windows it opened the log file with cp1252 (locale default). Lines containing \`✓\` (used in prereq-status output) hit UnicodeEncodeError on emit, producing alarming \`--- Logging error ---\` tracebacks on stderr even though the install completed. Adds \`"encoding": "utf-8"\` to the dictConfig.

## Jira
[TG-1084](https://datakitchen.atlassian.net/browse/TG-1084)

## Test plan
- [x] Full suite still passes locally (182 tests).
- [x] \`ruff check\` + \`ruff format --check\` clean.
- [x] Helper is a silent no-op on a clean dev machine.
- [ ] Windows: with an orphan \`postgres.exe\` from a prior dirty exit, \`tg install\` completes (the failing case from \`chip_installer_logs.txt\`).
- [ ] Windows: with an orphan \`testgen.exe\`, \`tg delete\` completes including binary removal.
- [ ] Windows: install log file \`installer_log.txt\` contains \`✓\` characters without the \`--- Logging error ---\` traceback (the failing case from \`chip_install.txt\`).